### PR TITLE
convex hull shape calcs

### DIFF
--- a/fastrad/features/shape_utils.py
+++ b/fastrad/features/shape_utils.py
@@ -1,5 +1,9 @@
+import numpy as np
+from scipy.spatial import ConvexHull
+
 import torch
 from .shape_tables import gridAngles, vertList, triTable
+
 
 def calculate_mesh_features(mask_tensor, spacing):
     device = mask_tensor.device
@@ -105,25 +109,46 @@ def calculate_mesh_features(mask_tensor, spacing):
     if len(all_vertices_list) > 0:
         all_vertices = torch.cat(all_vertices_list, dim=0)
         unique_vertices = torch.unique(all_vertices, dim=0)
-        
-        # Compute pairwise distances
-        # dists will be shape (N, N)
-        dists = torch.cdist(unique_vertices, unique_vertices)
-        max_3d_diameter = dists.max().item()
-        
-        # For 2D diameters, we check pairwise elements that share the same coordinate
-        # PyRadiomics definition:
-        # diameter[0] -> a[0] == b[0] -> same Z -> Slice
-        # diameter[1] -> a[1] == b[1] -> same Y -> Column
-        # diameter[2] -> a[2] == b[2] -> same X -> Row
-        same_z = (unique_vertices[:, 0:1] == unique_vertices[:, 0:1].T)
-        max_2d_slice = torch.where(same_z, dists, torch.tensor(0.0, device=device)).max().item()
-        
-        same_y = (unique_vertices[:, 1:2] == unique_vertices[:, 1:2].T)
-        max_2d_col = torch.where(same_y, dists, torch.tensor(0.0, device=device)).max().item()
-        
-        same_x = (unique_vertices[:, 2:3] == unique_vertices[:, 2:3].T)
-        max_2d_row = torch.where(same_x, dists, torch.tensor(0.0, device=device)).max().item()
+
+        # Compute convex hull of vertices
+        verts_np = unique_vertices.cpu().numpy()
+        hull = ConvexHull(verts_np)
+        hull_pts = torch.tensor(verts_np[hull.vertices], device=unique_vertices.device)
+
+        # Max diameter of mesh is same as that of its convex hull
+        max_3d_diameter = torch.cdist(hull_pts, hull_pts).max().item()
+
+        # Iterate over z,x,y dims for max 2D diameters
+        dims = [0,1,2]
+        max_2d_diameters = [0.0, 0.0, 0.0]
+
+        for i in dims:
+            sl = unique_vertices[:, i]
+            keep_dims = [j for j in dims if j != i]
+
+            for s in torch.unique(sl):
+                pts = unique_vertices[sl == s]
+
+                # Calculate plane rank to determine collinearity of points
+                pts_np = pts[:, keep_dims].cpu().numpy()
+                centered = pts_np - pts_np.mean(axis=0)
+                plane_rank = np.linalg.matrix_rank(centered)
+                
+                if plane_rank < 2:
+                    # If points are colinear, calculate all pairwise distances
+                    pts_t = torch.tensor(pts_np, device=pts.device)
+                    d = torch.cdist(torch.tensor(pts_np), torch.tensor(pts_np))
+                else:
+                    # If plane slice is truly 2D, only calculate convex hull distances
+                    hull = ConvexHull(pts_np)
+                    hull_pts = torch.tensor(pts_np[hull.vertices], device=pts.device)
+                    d = torch.cdist(hull_pts, hull_pts)
+            
+                max_2d_diameters[i] = max(max_2d_diameters[i], d.max().item())
+
+        # Unpack 2D max diameters
+        max_2d_slice, max_2d_col, max_2d_row = max_2d_diameters
+
     else:
         max_3d_diameter = 0.0
         max_2d_slice = 0.0

--- a/fastrad/features/shape_utils.py
+++ b/fastrad/features/shape_utils.py
@@ -4,7 +4,6 @@ from scipy.spatial import ConvexHull
 import torch
 from .shape_tables import gridAngles, vertList, triTable
 
-
 def calculate_mesh_features(mask_tensor, spacing):
     device = mask_tensor.device
     
@@ -117,6 +116,12 @@ def calculate_mesh_features(mask_tensor, spacing):
 
         # Max diameter of mesh is same as that of its convex hull
         max_3d_diameter = torch.cdist(hull_pts, hull_pts).max().item()
+
+        # For 2D diameters, we check pairwise elements that share the same coordinate
+        # PyRadiomics definition:
+        # diameter[0] -> a[0] == b[0] -> same Z -> Slice
+        # diameter[1] -> a[1] == b[1] -> same Y -> Column
+        # diameter[2] -> a[2] == b[2] -> same X -> Row
 
         # Iterate over z,x,y dims for max 2D diameters
         dims = [0,1,2]


### PR DESCRIPTION
Suggested fix for https://github.com/helloerikaaa/fastrad/issues/8

Idea: We can substitute a computation of max distance over all pairwise distances in mesh with one over its (much smaller) convex hull (see: https://cgm.cs.mcgill.ca/~athens/cs507/Projects/2000/MS/diameter/node2.html)

Pros: Reduces memory consumption for mesh_volume and maximum_diameter calculations significantly.
Cons: Requires some CPU-GPU copy overhead (numpy-torch-numpy) to use scipy's convex hull calculator. Alternately, a torch-native convex hull calculator could be used.

I tested locally on my own example images that this change does not change the values for mesh_volume and the three maximum_2D diameter and also verified with your test suite that IBSI compliance holds. In my example images, this change brought the memory consumption of the torch.cdist result from >80 GB to less than 5 MB.

Verification that IBSI-compliance is not affected by change:

<img width="1097" height="328" alt="image" src="https://github.com/user-attachments/assets/1208d105-ae08-42c2-9d0a-3b49f47dfe8e" />

<img width="537" height="226" alt="image" src="https://github.com/user-attachments/assets/342d5afe-5fce-4891-9370-311cd355be89" />

